### PR TITLE
feat: Adapt to HarmonyOS NEXT

### DIFF
--- a/DropdownAlert.tsx
+++ b/DropdownAlert.tsx
@@ -269,6 +269,8 @@ const DropdownAlert: React.FunctionComponent<DropdownAlertProps> = ({
   const windowDimensions = useWindowDimensions();
   const isIOS = Platform.OS === 'ios';
   const isAndroid = Platform.OS === 'android';
+  const isHarmony = Platform.OS === 'harmony';
+
   const isBelowIOS11 = isIOS && Number(Platform.Version) < 11;
   const [dimValue, setDimValue] = useState(0);
   const [height, setHeight] = useState(99);
@@ -411,7 +413,7 @@ const DropdownAlert: React.FunctionComponent<DropdownAlertProps> = ({
 
   function _updateStatusBar(active = false, type = '') {
     if (updateStatusBar && alertPosition === DropdownAlertPosition.Top) {
-      if (isAndroid) {
+      if (isAndroid||isHarmony) {
         if (active) {
           let backgroundColor = activeStatusBarBackgroundColor;
           if (!backgroundColor) {
@@ -607,11 +609,11 @@ const DropdownAlert: React.FunctionComponent<DropdownAlertProps> = ({
     let additionalAlertViewStyle: ViewStyle = {
       backgroundColor: _getBackgroundColorForType(alertData.type),
     };
-    if (isAndroid && translucent) {
+    if ((isAndroid ||isHarmony) && translucent) {
       additionalAlertViewStyle.marginTop = StatusBar.currentHeight;
     }
     let SafeView = SafeAreaView;
-    if (isBelowIOS11 || isAndroid) {
+    if (isBelowIOS11 || isAndroid || isHarmony) {
       SafeView = View;
     }
     return (

--- a/README.md
+++ b/README.md
@@ -1,89 +1,19 @@
-# react-native-dropdownalert
+# @react-native-oh-tpl/react-native-dropdownalert
 
-[![Platform](https://img.shields.io/badge/-react--native-grey.svg?style=for-the-badge&logo=react)](https://reactnative.dev)
-[![npm version](https://img.shields.io/npm/v/react-native-dropdownalert.svg?style=for-the-badge&logo=npm)](https://www.npmjs.com/package/react-native-dropdownalert)
-[![npm version](https://img.shields.io/npm/dm/react-native-dropdownalert.svg?style=for-the-badge&logo=npm)](https://www.npmjs.com/package/react-native-dropdownalert)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge)](https://raw.github.com/testshallpass/react-native-dropdownalert/master/LICENSE)
-[![CI](https://github.com/testshallpass/react-native-dropdownalert/actions/workflows/ci.yml/badge.svg)](https://github.com/testshallpass/react-native-dropdownalert/actions/workflows/ci.yml)
+本项目基于 [react-native-dropdownalert](https://github.com/testshallpass/react-native-dropdownalert)
 
-![screenshot](./screenshots/demo.gif)
+## 文档地址 / Documentation URL 
 
-## Table of contents
+[中文 / Chinese](https://gitee.com/react-native-oh-library/usage-docs/blob/master/zh-cn/react-native-dropdownalert.md)
 
-- [Installation](#installation)
-- [Usage](#usage)
-- [Support](#support)
-- [Using children prop](#using-children-prop)
-- [Caveats](#caveats)
-- [More Examples](./example/App.tsx)
+[英文 / English](https://gitee.com/react-native-oh-library/usage-docs/blob/master/zh-en/react-native-dropdownalert.md)
 
-An alert to notify users about an error or something else. It can be dismissed by press, cancel, automatic, pan gesture or programmatic. It can be customized and/or you can build your own alert (BYOA) - see [DropdownAlertProps](./DropdownAlert.tsx) on what's available.
+## Codegen
 
-## Installation
+该库已接入 codegen，具体请查阅文档。
 
-- `yarn add react-native-dropdownalert`
-- `npm i react-native-dropdownalert --save`
+The library has been integrated with codegen. Please refer to the documentation for details.
 
-## Usage
+## 请悉知 / Acknowledgements
 
-import the library
-
-```javascript
-import DropdownAlert, {
-  DropdownAlertData,
-  DropdownAlertType,
-} from 'react-native-dropdownalert';
-```
-
-create an alert promise function variable
-
-```javascript
-let alert = (_data: DropdownAlertData) => new Promise<DropdownAlertData>(res => res);
-```
-
-add the component as the last component in the document tree so it overlaps other UI components and set alert prop with alert function
-
-```javascript
-<DropdownAlert alert={func => (alert = func)} />
-```
-
-invoke alert
-
-```javascript
-const alertData = await alert({
-  type: DropdownAlertType.Error,
-  title: 'Error',
-  message: 'Something went wrong.',
-});
-```
-
-## Support
-
-| react minium version | react-native minium version | package version | reason              |
-| :------------------: | :-------------------------: | :-------------: | ------------------- |
-|       v16.8.0        |           v0.61.0           |     v5.0.0      | use react hooks     |
-|       v16.0.0        |           v0.50.0           |     v3.2.0      | use `SafeAreaView`  |
-|   v16.0.0-alpha.6    |           v0.44.0           |     v2.12.0     | use `ViewPropTypes` |
-
-## Using `children` prop
-
-Option 1 pass child component(s) like so:
-
-```javascript
-<DropdownAlert>{/* insert child component(s) */}</DropdownAlert>
-```
-
-Option 2 pass child component(s) like so:
-
-```javascript
-<DropdownAlert children={/* insert child component(s) */} />
-```
-
-Either way `DropdownAlert` will render these instead of the pre-defined child components when alert is invoked. Check out the iOS and Android notifications in example project.
-
-## Caveats
-
-- Modals can overlap `DropdownAlert`` if it is not inside the modal's document tree.
-- It is important you place the `DropdownAlert` below the `StackNavigator`.
-
-> Inspired by: [RKDropdownAlert](https://github.com/cwRichardKim/RKDropdownAlert)
+本项目基于 [MIT License (MIT)](https://github.com/testshallpass/react-native-dropdownalert/blob/main/LICENSE) ，请自由地享受和参与开源。

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-dropdownalert",
+  "name": "@react-native-oh-tpl/react-native-dropdownalert",
   "version": "5.1.0",
   "description": "An alert to notify users about an error or something else.",
   "main": "DropdownAlert.tsx",
@@ -11,12 +11,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/testshallpass/react-native-dropdownalert.git"
+    "url": "git://github.com/react-native-oh-library/react-native-dropdownalert.git" 
   },
   "keywords": [
     "react-native",
     "ios",
     "android",
+    "harmony"
     "dropdown",
     "alert",
     "dismiss",
@@ -51,5 +52,8 @@
     "ts-jest": "29.1.1",
     "ts-node": "10.9.2",
     "typescript": "5.0.4"
+  },
+  "harmony": {
+    "alias": "react-native-dropdownalert"
   }
 }


### PR DESCRIPTION
# Summary

适配harmony issue #1

- 修改内容
在`DropdownAlert.tsx`中增加`const isHarmony  = Platform.OS === 'harmony'`的判断 ，并在只支持`isAndroid`的逻辑判断里加上 `|| isHarmony `，使某些`Android`独有属性也支持`harmony`

## Test Plan

[测试代码地址](/react-native-oh-library/RNOHDCS/tree/main/react-native-dropdownalert)

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例（如需要）
- [x] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)

